### PR TITLE
Add percentages to counts report

### DIFF
--- a/opentargets_pharmgkb/counts.py
+++ b/opentargets_pharmgkb/counts.py
@@ -1,3 +1,11 @@
+def format_percent(part, total):
+    return f'{part / total:.2%}'
+
+
+def format_decimal(part, total):
+    return f'{part / total:.2}'
+
+
 class ClinicalAnnotationCounts:
     """Simple class to hold counts for generating clinical annotation evidence."""
 
@@ -23,19 +31,28 @@ class ClinicalAnnotationCounts:
 
     def report(self):
         report_str = f'\nTotal clinical annotations: {self.clinical_annotations}\n'
-        report_str += f'\tWith RS: {self.with_rs}\n'
-        report_str += f'Exploded by allele: {self.exploded_alleles}\n'
-        report_str += f'Exploded by drug: {self.exploded_drugs}\n'
-        report_str += f'Exploded by phenotype: {self.exploded_phenotypes}\n'
+        report_str += f'\tWith RS: {self.with_rs} ({format_percent(self.with_rs, self.clinical_annotations)})\n'
+        report_str += (f'\t\t1. Exploded by allele: {self.exploded_alleles} '
+                       f'({format_decimal(self.exploded_alleles, self.with_rs)}x)\n')
+        report_str += (f'\t\t2. Exploded by drug: {self.exploded_drugs} '
+                       f'({format_decimal(self.exploded_drugs, self.exploded_alleles)}x)\n')
+        report_str += (f'\t\t3. Exploded by phenotype: {self.exploded_phenotypes}'
+                       f' ({format_decimal(self.exploded_phenotypes, self.exploded_drugs)}x)\n')
         report_str += f'Total evidence strings: {self.evidence_strings}\n'
-        report_str += f'\tWith CHEBI: {self.with_chebi}\n'
-        report_str += f'\tWith EFO phenotype: {self.with_efo}\n'
-        report_str += f'\tWith functional consequence: {self.with_consequence}\n'
+        report_str += f'\tWith CHEBI: {self.with_chebi} ({format_percent(self.with_chebi, self.evidence_strings)})\n'
+        report_str += (f'\tWith EFO phenotype: {self.with_efo}'
+                       f' ({format_percent(self.with_efo, self.evidence_strings)})\n')
+        report_str += (f'\tWith functional consequence: {self.with_consequence} '
+                       f'({format_percent(self.with_consequence, self.evidence_strings)})\n')
         # report_str += f'\tWith PGKB gene: {self.with_pgkb_gene}\n'
-        report_str += f'\tWith VEP gene: {self.with_vep_gene}\n'
+        report_str += (f'\tWith VEP gene: {self.with_vep_gene} '
+                       f'({format_percent(self.with_vep_gene, self.evidence_strings)})\n')
         report_str += f'Gene comparisons per annotation\n'
-        report_str += f'\tWith PGKB genes: {self.annot_with_pgkb_genes}\n'
-        report_str += f'\tWith VEP genes: {self.annot_with_vep_genes}\n'
-        report_str += f'\tPGKB genes != VEP genes: {self.pgkb_vep_gene_diff}\n'
+        report_str += (f'\tWith PGKB genes: {self.annot_with_pgkb_genes} '
+                       f'({format_percent(self.annot_with_pgkb_genes, self.clinical_annotations)})\n')
+        report_str += (f'\tWith VEP genes: {self.annot_with_vep_genes} '
+                       f'({format_percent(self.annot_with_vep_genes, self.clinical_annotations)})\n')
+        report_str += (f'\tPGKB genes != VEP genes: {self.pgkb_vep_gene_diff} '
+                       f'({format_percent(self.pgkb_vep_gene_diff, self.clinical_annotations)})\n')
         print(report_str)
         return report_str


### PR DESCRIPTION
Example report from tests:
```
Total clinical annotations: 10
	With RS: 9 (90.00%)
		1. Exploded by allele: 30 (3.3x)
		2. Exploded by drug: 66 (2.2x)
		3. Exploded by phenotype: 78 (1.2x)
Total evidence strings: 78
	With CHEBI: 60 (76.92%)
	With EFO phenotype: 30 (38.46%)
	With functional consequence: 42 (53.85%)
	With VEP gene: 42 (53.85%)
Gene comparisons per annotation
	With PGKB genes: 8 (80.00%)
	With VEP genes: 4 (40.00%)
	PGKB genes != VEP genes: 5 (50.00%)
```