### PR TITLE
Issue 36: Improve genotype ID algorithm

### DIFF
--- a/data-exploration/pgkb-vs-vep-genes.ipynb
+++ b/data-exploration/pgkb-vs-vep-genes.ipynb
@@ -1,0 +1,915 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "06b2bd24-070e-4ab0-a163-fa5157fe9d60",
+   "metadata": {},
+   "source": [
+    "## Comparison of PGKB and VEP genes\n",
+    "\n",
+    "We focus exclusively on RS ID records, as for named alleles we always use PGKB genes and do not go through VEP.\n",
+    "\n",
+    "First we look at the file of mismatches generated from the 2023-12 submission to get a quick idea of what we're dealing with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b74cee2b-4419-4c95-97cd-040feea93312",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import csv\n",
+    "import re\n",
+    "from collections import Counter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "94f0c3c0-d513-44cf-88dc-5436d4ff482b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def string_to_set(s):\n",
+    "    if s == 'set()':\n",
+    "        return set()\n",
+    "    return set(x for x in re.sub(r\"{|}|'\", '', s).split(', ') if x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "554fb947-ba05-4294-ae59-ce12ad7bd6d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pgkb_vep_genes = []\n",
+    "\n",
+    "# comparison file from 2023-12 release\n",
+    "filename = '/home/april/projects/opentargets/pharmgkb/vep-vs-pgkb/vep_vs_pgkb_genes.csv'\n",
+    "\n",
+    "with open(filename) as f:\n",
+    "    reader = csv.reader(f)\n",
+    "    next(reader)  # skip header\n",
+    "    for row in reader:\n",
+    "        pgkb_vep_genes.append({\n",
+    "            'id': row[0],\n",
+    "            'pgkb': string_to_set(row[1]),\n",
+    "            'vep': string_to_set(row[2])\n",
+    "        })"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8b7bd75b-da90-4073-a52f-3bb3ceaf0892",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "770"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# NB. includes only records where do not match\n",
+    "# See here: https://github.com/EBIvariation/opentargets-pharmgkb/issues/23\n",
+    "len(pgkb_vep_genes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "fbc4e14a-feee-467e-acf8-ff3f5a2a8759",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Counting logic borrowed from CMAT paper\n",
+    "\n",
+    "def get_f1_tp_fp_fn(pgkb_set, vep_set):\n",
+    "    \"\"\"Returns f1-score and number of true positives, false positives and false negatives.\"\"\"\n",
+    "    if len(pgkb_set) == 0 and len(vep_set) == 0:\n",
+    "        return 0, 0, 0, 0\n",
+    "    tp = len(vep_set & pgkb_set)\n",
+    "    fp = len(vep_set - pgkb_set)\n",
+    "    fn = len(pgkb_set - vep_set)\n",
+    "    return 2 * tp / (2 * tp + fp + fn), tp, fp, fn\n",
+    "    \n",
+    "\n",
+    "def count_and_match(pgkb_set, vep_set, counts):\n",
+    "    \"\"\"Return True if \"match\", False otherwise (mismatch == sets disjoint)\"\"\"\n",
+    "    pgkb_set = set(pgkb_set)\n",
+    "    vep_set = set(vep_set)\n",
+    "\n",
+    "    # First check if either set is empty\n",
+    "    if not pgkb_set and vep_set:\n",
+    "        counts['pgkb_missing'] += 1\n",
+    "    elif pgkb_set and not vep_set:\n",
+    "        counts['vep_missing'] += 1\n",
+    "    elif not pgkb_set and not vep_set:\n",
+    "        counts['both_missing'] += 1\n",
+    "\n",
+    "    # Both sets present, place in correct category\n",
+    "    else:\n",
+    "        _, true_pos, false_pos, false_neg = get_f1_tp_fp_fn(pgkb_set, vep_set)\n",
+    "        if false_pos and not false_neg:\n",
+    "            k = 'vep_superset'\n",
+    "        elif not false_pos and false_neg:\n",
+    "            k = 'vep_subset'\n",
+    "        elif not false_pos and not false_neg:\n",
+    "            k = 'exact_match'\n",
+    "        elif true_pos:\n",
+    "            k = 'divergent_match'\n",
+    "        else:\n",
+    "            k = 'mismatch'\n",
+    "        counts[k] += 1\n",
+    "        if k == 'mismatch':\n",
+    "            return False\n",
+    "    return True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1a053c37-6115-437e-ad53-9093d38a1b20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "counts = Counter()\n",
+    "mismatches = []\n",
+    "\n",
+    "for record in pgkb_vep_genes:\n",
+    "    if not count_and_match(record['pgkb'], record['vep'], counts):\n",
+    "        mismatches.append(record)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "33733bff-4244-4b6f-b7ba-9406d574f455",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({'vep_superset': 140,\n",
+       "         'vep_subset': 273,\n",
+       "         'mismatch': 106,\n",
+       "         'vep_missing': 182,\n",
+       "         'pgkb_missing': 61,\n",
+       "         'divergent_match': 8})"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Missing counts: exact_match, both_missing\n",
+    "counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ee9aeb2-35c2-49a2-9903-0708d6c1dc37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('/home/april/projects/opentargets/pharmgkb/vep-vs-pgkb/vep_vs_pgkb_mismatches.tsv', 'w+') as f:\n",
+    "    f.write('id\\tpgkb\\tvep\\n')\n",
+    "    f.write('\\n'.join('\\t'.join([x['id'], ','.join(x['pgkb']), ','.join(x['vep'])]) for x in mismatches))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3705cabc-0a40-41fd-b2f7-ca03b48645ba",
+   "metadata": {},
+   "source": [
+    "### Complete counts\n",
+    "\n",
+    "From the above we observe that the mismatching genes seem to be in close proximity, so we want to also look at the variant locations. We're also missing some counts, particularly cases where both PGKB and VEP genes are missing, which would be useful to get.\n",
+    "\n",
+    "Since we're running this again, might as well use the newest version of PGKB data though the differences will be minor (if anything)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "87000979-c0ad-47d0-9cb3-0dc334f1e58f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from opentargets_pharmgkb.evidence_generation import explode_and_map_genes, get_functional_consequences, get_genotype_ids, ID_COL_NAME\n",
+    "from opentargets_pharmgkb.pandas_utils import read_tsv_to_df\n",
+    "\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "27861f6f-9343-4c44-be4f-4bf70e39eee4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dir = '/home/april/projects/opentargets/pharmgkb/vep-vs-pgkb'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c87bbc9-4c87-40a0-84d5-de9249f50192",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download new data (2024-03-05)\n",
+    "!cd {data_dir}\n",
+    "\n",
+    "!wget -q https://api.pharmgkb.org/v1/download/file/data/clinicalAnnotations.zip\n",
+    "!wget -q https://api.pharmgkb.org/v1/download/file/data/variants.zip\n",
+    "\n",
+    "!unzip -jq clinicalAnnotations.zip \"*.tsv\" -d {data_dir}\n",
+    "!unzip -jq variants.zip \"*.tsv\" -d {data_dir}\n",
+    "\n",
+    "!rm clinicalAnnotations.zip variants.zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b7f9fbb2-a8a3-47d2-8275-9eb8c21f9a93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Adapted from evidence generation pipeline\n",
+    "clinical_annot_path = os.path.join(data_dir, 'clinical_annotations.tsv')\n",
+    "clinical_alleles_path = os.path.join(data_dir, 'clinical_ann_alleles.tsv')\n",
+    "variants_path = os.path.join(data_dir, 'variants.tsv')\n",
+    "fasta_path = '/home/april/projects/opentargets/pharmgkb/assembly/GCF_000001405.40_GRCh38.p14_genomic.fna'\n",
+    "\n",
+    "clinical_annot_table = read_tsv_to_df(clinical_annot_path)\n",
+    "clinical_alleles_table = read_tsv_to_df(clinical_alleles_path)\n",
+    "variants_table = read_tsv_to_df(variants_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "654907ce-e80c-473b-96e1-77083dd0e32d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "merged_with_variants_table = pd.merge(clinical_annot_table, variants_table, left_on='Variant/Haplotypes', right_on='Variant Name', how='left')\n",
+    "merged_with_alleles_table = pd.merge(merged_with_variants_table, clinical_alleles_table, on=ID_COL_NAME, how='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "99143e1e-ead0-49e4-af0f-cb45e2ba76e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with_rs = merged_with_alleles_table[merged_with_alleles_table['Variant/Haplotypes'].str.startswith('rs')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "f93c1e09-a60b-4002-9fa3-46d81ee378b9",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (AGCCCACCC)12/(AGCCCACCC)12\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)2\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)3/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (AGCCCACCC)12/(AGCCCACCC)12\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)2\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)3/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)2\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)3/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CA)16/(CA)16\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CA)16/(CA)17\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CA)17/(CA)17\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype CCCCCCC\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype CCCCCCC\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype CCCCCCC\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCCACCCGA)9\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCCACCCGA)10\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype CCCACCCGA)12/(CCCACCCGA)12\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)2\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)3/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCCACCCGA)9/(CCCACCCGA)9\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCCACCCGA)10/(CCCACCCGA)9\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCCACCCGA)10/(CCCACCCGA)10\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCCACCCGA)12/(CCCACCCGA)9\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCCACCCGA)12/(CCCACCCGA)10\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCCACCCGA)12/(CCCACCCGA)12\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)2\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)3/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)2\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)3/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)2\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)2/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (CCGCGCCACTTGGCCTGCCTCCGTCCCG)3/(CCGCGCCACTTGGCCTGCCTCCGTCCCG)3\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (T)7/(T)7\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (T)7/(T)8\n",
+      "ERROR:opentargets_pharmgkb:Could not parse genotype (T)8/(T)8\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs746071566\tAGGAGTCGGAGTCGGAGTCG\tGGAGTC,DEL\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs61767072\tGGGCCGGGGGCGG\tGGGGCGGGGCCG,DEL\n",
+      "WARNING:opentargets_pharmgkb:Could not parse any genotypes for rs57098334\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs1048943\tT\tA,G\n",
+      "WARNING:opentargets_pharmgkb:Could not parse any genotypes for rs45445694\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs35068180\tGAAAA\tA,DEL\n",
+      "WARNING:opentargets_pharmgkb:Could not parse any genotypes for rs11568315\n",
+      "WARNING:opentargets_pharmgkb:Could not get chromosome number for NC_012920.1\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs61824877\tG\tA,T\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs71486745\tCTGTG\tGT,DEL\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs144854329\tTGGTCCCACTCTTCCCACAGG\tGGTCCCACTCTTCCCACA,DEL\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs17885382\tC\tA,T\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs700518\tT\tA,C\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs28364032\tG\tC,T\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs57064725\tC\tA,G\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs72549309\tGATGAATGA\tATGA,DEL\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs2228171\tC\tA,G\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs111618861\tCAAAAA\tA,DEL\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs201279313\tTATT\tTTA,DEL\n",
+      "WARNING:opentargets_pharmgkb:Ref not in alleles: rs10170310\tG\tA,C\n",
+      "WARNING:opentargets_pharmgkb:Could not parse any genotypes for rs143004875\n"
+     ]
+    }
+   ],
+   "source": [
+    "genotype_ids_table = get_genotype_ids(with_rs, fasta_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a95c17ed-30ad-43da-be3f-e1779e0f54c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rs_consequences_table = get_functional_consequences(genotype_ids_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "c9a49a19-8a51-4baa-ba68-b1d1ac5ef4b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:cmat.consequence_prediction.common.biomart:Processing chunk of 741 records\n",
+      "INFO:cmat.consequence_prediction.common.biomart:Processing chunk of 337 records\n"
+     ]
+    }
+   ],
+   "source": [
+    "mapped_genes = explode_and_map_genes(rs_consequences_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "4e23378f-e037-4daf-8ea0-f636bc466d74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Re-group by ID column\n",
+    "genes_table = mapped_genes.groupby(by=ID_COL_NAME).aggregate(\n",
+    "    original_gene=('Gene', lambda x: x.iloc[0] if len(x) > 0 else None),\n",
+    "    variant_location=('Location', lambda x: x.iloc[0] if len(x) > 0 else None),\n",
+    "    all_pgkb_genes=('gene_from_pgkb', lambda x: set(x.dropna())),\n",
+    "    all_vep_genes=('overlapping_gene', lambda x: set(x.dropna()))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "ebe04f8b-0237-467e-966e-3d7b682d1ebe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>original_gene</th>\n",
+       "      <th>variant_location</th>\n",
+       "      <th>all_pgkb_genes</th>\n",
+       "      <th>all_vep_genes</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Clinical Annotation ID</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1043858606</th>\n",
+       "      <td>BDNF</td>\n",
+       "      <td>NC_000011.10:27658369</td>\n",
+       "      <td>{ENSG00000176697}</td>\n",
+       "      <td>{ENSG00000176697}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1043858615</th>\n",
+       "      <td>GNB3</td>\n",
+       "      <td>NC_000012.12:6845711</td>\n",
+       "      <td>{ENSG00000111664}</td>\n",
+       "      <td>{ENSG00000111665, ENSG00000111664}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1043858632</th>\n",
+       "      <td>TPH1</td>\n",
+       "      <td>NC_000011.10:18026269</td>\n",
+       "      <td>{ENSG00000129167}</td>\n",
+       "      <td>{ENSG00000129167}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1043858637</th>\n",
+       "      <td>CEP68</td>\n",
+       "      <td>NC_000002.12:65069664</td>\n",
+       "      <td>{ENSG00000011523}</td>\n",
+       "      <td>{ENSG00000011523}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1043858642</th>\n",
+       "      <td>FSIP1</td>\n",
+       "      <td>NC_000015.10:39770852</td>\n",
+       "      <td>{ENSG00000150667}</td>\n",
+       "      <td>{ENSG00000150667}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>982046386</th>\n",
+       "      <td>ADRA2C</td>\n",
+       "      <td>NC_000004.12:3767577_3767588</td>\n",
+       "      <td>{ENSG00000184160}</td>\n",
+       "      <td>{}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>982047840</th>\n",
+       "      <td>GCLC</td>\n",
+       "      <td>NC_000006.12:53527310</td>\n",
+       "      <td>{ENSG00000001084}</td>\n",
+       "      <td>{ENSG00000001084}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>982047849</th>\n",
+       "      <td>DRD3</td>\n",
+       "      <td>NC_000003.12:114171968</td>\n",
+       "      <td>{ENSG00000151577}</td>\n",
+       "      <td>{ENSG00000151577}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>982047862</th>\n",
+       "      <td>ACE</td>\n",
+       "      <td>NC_000017.11:63488544</td>\n",
+       "      <td>{ENSG00000159640}</td>\n",
+       "      <td>{ENSG00000159640}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>982047910</th>\n",
+       "      <td>ACE</td>\n",
+       "      <td>NC_000017.11:63488544</td>\n",
+       "      <td>{ENSG00000159640}</td>\n",
+       "      <td>{ENSG00000159640}</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>4505 rows × 4 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       original_gene              variant_location  \\\n",
+       "Clinical Annotation ID                                               \n",
+       "1043858606                      BDNF         NC_000011.10:27658369   \n",
+       "1043858615                      GNB3          NC_000012.12:6845711   \n",
+       "1043858632                      TPH1         NC_000011.10:18026269   \n",
+       "1043858637                     CEP68         NC_000002.12:65069664   \n",
+       "1043858642                     FSIP1         NC_000015.10:39770852   \n",
+       "...                              ...                           ...   \n",
+       "982046386                     ADRA2C  NC_000004.12:3767577_3767588   \n",
+       "982047840                       GCLC         NC_000006.12:53527310   \n",
+       "982047849                       DRD3        NC_000003.12:114171968   \n",
+       "982047862                        ACE         NC_000017.11:63488544   \n",
+       "982047910                        ACE         NC_000017.11:63488544   \n",
+       "\n",
+       "                           all_pgkb_genes                       all_vep_genes  \n",
+       "Clinical Annotation ID                                                         \n",
+       "1043858606              {ENSG00000176697}                   {ENSG00000176697}  \n",
+       "1043858615              {ENSG00000111664}  {ENSG00000111665, ENSG00000111664}  \n",
+       "1043858632              {ENSG00000129167}                   {ENSG00000129167}  \n",
+       "1043858637              {ENSG00000011523}                   {ENSG00000011523}  \n",
+       "1043858642              {ENSG00000150667}                   {ENSG00000150667}  \n",
+       "...                                   ...                                 ...  \n",
+       "982046386               {ENSG00000184160}                                  {}  \n",
+       "982047840               {ENSG00000001084}                   {ENSG00000001084}  \n",
+       "982047849               {ENSG00000151577}                   {ENSG00000151577}  \n",
+       "982047862               {ENSG00000159640}                   {ENSG00000159640}  \n",
+       "982047910               {ENSG00000159640}                   {ENSG00000159640}  \n",
+       "\n",
+       "[4505 rows x 4 columns]"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "genes_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "908cb0dc-2c26-47fb-bd77-d5f285ebf5b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "genes_table.to_csv(os.path.join(data_dir, 'all-pgkb-vep-genes.csv'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "0ad6f5e9-ad82-4290-a6d5-0bf6c1a774a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "complete_counts = Counter()\n",
+    "complete_mismatches = []\n",
+    "\n",
+    "for record in genes_table.itertuples():\n",
+    "    if not count_and_match(record.all_pgkb_genes, record.all_vep_genes, complete_counts):\n",
+    "        complete_mismatches.append(record)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "29dfee03-5783-40ce-8f83-fc471ce7b009",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({'exact_match': 3535,\n",
+       "         'vep_superset': 143,\n",
+       "         'vep_subset': 271,\n",
+       "         'both_missing': 196,\n",
+       "         'mismatch': 106,\n",
+       "         'vep_missing': 185,\n",
+       "         'pgkb_missing': 61,\n",
+       "         'divergent_match': 8})"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "complete_counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "9745cd5b-36ba-4a13-ac3e-2990b3f3d87d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "245"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# records without an original gene in PGKB\n",
+    "len(genes_table[genes_table['original_gene'].isna()])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "793241e4-9798-4f52-85d6-333b86579997",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>original_gene</th>\n",
+       "      <th>variant_location</th>\n",
+       "      <th>all_pgkb_genes</th>\n",
+       "      <th>all_vep_genes</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Clinical Annotation ID</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1183547855</th>\n",
+       "      <td>UGT1A</td>\n",
+       "      <td>NC_000002.12:233772999</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{ENSG00000242515, ENSG00000244122, ENSG0000024...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1183614816</th>\n",
+       "      <td>UGT1A</td>\n",
+       "      <td>NC_000002.12:233772770</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{ENSG00000242515, ENSG00000244122, ENSG0000024...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1183614825</th>\n",
+       "      <td>UGT1A</td>\n",
+       "      <td>NC_000002.12:233772770</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{ENSG00000242515, ENSG00000244122, ENSG0000024...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1183614855</th>\n",
+       "      <td>UGT1A</td>\n",
+       "      <td>NC_000002.12:233772898</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{ENSG00000242515, ENSG00000244122, ENSG0000024...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1183614860</th>\n",
+       "      <td>UGT1A</td>\n",
+       "      <td>NC_000002.12:233772898</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{ENSG00000242515, ENSG00000244122, ENSG0000024...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1183698808</th>\n",
+       "      <td>NPPA-AS1</td>\n",
+       "      <td>NC_000001.11:11847591</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{ENSG00000175206}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1445401413</th>\n",
+       "      <td>UGT1A</td>\n",
+       "      <td>NC_000002.12:233774704</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{ENSG00000185038}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1445401420</th>\n",
+       "      <td>UGT1A</td>\n",
+       "      <td>NC_000002.12:233774704</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{ENSG00000185038}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1448112614</th>\n",
+       "      <td>RARS</td>\n",
+       "      <td>NC_000005.10:168491921</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{ENSG00000113643}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1449168447</th>\n",
+       "      <td>TTC37</td>\n",
+       "      <td>NC_000005.10:95466585</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{ENSG00000198677}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1449168454</th>\n",
+       "      <td>TTC37</td>\n",
+       "      <td>NC_000005.10:95481198</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{ENSG00000198677}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1451117640</th>\n",
+       "      <td>C5orf56</td>\n",
+       "      <td>NC_000005.10:132448701</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>{}</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                       original_gene        variant_location all_pgkb_genes  \\\n",
+       "Clinical Annotation ID                                                        \n",
+       "1183547855                     UGT1A  NC_000002.12:233772999             {}   \n",
+       "1183614816                     UGT1A  NC_000002.12:233772770             {}   \n",
+       "1183614825                     UGT1A  NC_000002.12:233772770             {}   \n",
+       "1183614855                     UGT1A  NC_000002.12:233772898             {}   \n",
+       "1183614860                     UGT1A  NC_000002.12:233772898             {}   \n",
+       "1183698808                  NPPA-AS1   NC_000001.11:11847591             {}   \n",
+       "1445401413                     UGT1A  NC_000002.12:233774704             {}   \n",
+       "1445401420                     UGT1A  NC_000002.12:233774704             {}   \n",
+       "1448112614                      RARS  NC_000005.10:168491921             {}   \n",
+       "1449168447                     TTC37   NC_000005.10:95466585             {}   \n",
+       "1449168454                     TTC37   NC_000005.10:95481198             {}   \n",
+       "1451117640                   C5orf56  NC_000005.10:132448701             {}   \n",
+       "\n",
+       "                                                            all_vep_genes  \n",
+       "Clinical Annotation ID                                                     \n",
+       "1183547855              {ENSG00000242515, ENSG00000244122, ENSG0000024...  \n",
+       "1183614816              {ENSG00000242515, ENSG00000244122, ENSG0000024...  \n",
+       "1183614825              {ENSG00000242515, ENSG00000244122, ENSG0000024...  \n",
+       "1183614855              {ENSG00000242515, ENSG00000244122, ENSG0000024...  \n",
+       "1183614860              {ENSG00000242515, ENSG00000244122, ENSG0000024...  \n",
+       "1183698808                                              {ENSG00000175206}  \n",
+       "1445401413                                              {ENSG00000185038}  \n",
+       "1445401420                                              {ENSG00000185038}  \n",
+       "1448112614                                              {ENSG00000113643}  \n",
+       "1449168447                                              {ENSG00000198677}  \n",
+       "1449168454                                              {ENSG00000198677}  \n",
+       "1451117640                                                             {}  "
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# records with a gene we couldn't map to ensembl gene id\n",
+    "genes_table[~genes_table['original_gene'].isna() & (genes_table['all_pgkb_genes'].str.len() == 0)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "5ba65a79-8f08-44d6-8539-34e4e527d8fb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "original_gene                                 DPYD\n",
+       "variant_location    NC_000001.11:97740411_97740418\n",
+       "all_pgkb_genes                   {ENSG00000188641}\n",
+       "all_vep_genes                                   {}\n",
+       "Name: 1447989678, dtype: object"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# confirm the record highlighted by OT has a gene\n",
+    "genes_table.loc['1447989678']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "id": "b28bc46c-2063-423e-82fc-db0917ca0d2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def write_genes_df(df, outfile):\n",
+    "    # df is actually an iterable of named tuples, not a dataframe...\n",
+    "    with open(outfile, 'w+') as f:\n",
+    "        f.write('id\\tlocation\\toriginal\\tpgkb\\tvep\\n')\n",
+    "        f.write('\\n'.join('\\t'.join([x.Index, x.variant_location, x.original_gene, ','.join(x.all_pgkb_genes), ','.join(x.all_vep_genes)])\n",
+    "                          for x in df))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "id": "e63dd3f5-568d-45a1-9bc4-248ea4736a98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# save the mismatches again, but with original gene & variant location\n",
+    "write_genes_df(complete_mismatches, os.path.join(data_dir, 'complete_vep_vs_pgkb_mismatches.tsv'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "id": "98ef4506-22b3-4d7f-be32-b5df0cd3d035",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# also save the unmapped genes\n",
+    "write_genes_df(genes_table[~genes_table['original_gene'].isna() & (genes_table['all_pgkb_genes'].str.len() == 0)].itertuples(),\n",
+    "               os.path.join(data_dir, 'unmapped_genes.tsv'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80dffee3-3920-4491-b103-4ce3ab33d013",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/opentargets_pharmgkb/evidence_generation.py
+++ b/opentargets_pharmgkb/evidence_generation.py
@@ -25,7 +25,7 @@ logger.setLevel(level=logging.DEBUG)
 ID_COL_NAME = 'Clinical Annotation ID'
 
 
-def pipeline(data_dir, fasta_path, created_date, output_path, debug_path=None):
+def pipeline(data_dir, fasta_path, created_date, output_path):
     clinical_annot_path = os.path.join(data_dir, 'clinical_annotations.tsv')
     clinical_alleles_path = os.path.join(data_dir, 'clinical_ann_alleles.tsv')
     clinical_evidence_path = os.path.join(data_dir, 'clinical_ann_evidence.tsv')
@@ -108,11 +108,6 @@ def pipeline(data_dir, fasta_path, created_date, output_path, debug_path=None):
                 invalid_evidence = True
 
     # Final count report
-    # NB. gene comparison conflicts with named allele processing,
-    #  restore if needed for https://github.com/EBIvariation/opentargets-pharmgkb/issues/21
-    # if not debug_path:
-    #     debug_path = f'{output_path.rsplit(".", 1)[0]}_genes.csv'
-    # gene_comparison_counts(evidence_table, counts, debug_path=debug_path)
     counts.report()
 
     # Exit with an error code if any invalid evidence is produced
@@ -150,6 +145,7 @@ def get_genotype_ids(df, fasta_path, counts=None):
     for i, row in df_with_ids.drop_duplicates(['Variant/Haplotypes']).iterrows():
         chrom, pos, ref, alleles_dict = fasta.get_chr_pos_ref(row['Variant/Haplotypes'], row['Location'],
                                                               row['all_genotypes'])
+        # TODO - here fallback on NCBI SPDI method
         rs_to_coords[row['Variant/Haplotypes']] = (chrom, pos, ref, alleles_dict)
         # Generate per-variant counts, if applicable
         if not counts:

--- a/opentargets_pharmgkb/evidence_generation.py
+++ b/opentargets_pharmgkb/evidence_generation.py
@@ -145,7 +145,6 @@ def get_genotype_ids(df, fasta_path, counts=None):
     for i, row in df_with_ids.drop_duplicates(['Variant/Haplotypes']).iterrows():
         chrom, pos, ref, alleles_dict = fasta.get_chr_pos_ref(row['Variant/Haplotypes'], row['Location'],
                                                               row['all_genotypes'])
-        # TODO - here fallback on NCBI SPDI method
         rs_to_coords[row['Variant/Haplotypes']] = (chrom, pos, ref, alleles_dict)
         # Generate per-variant counts, if applicable
         if not counts:

--- a/opentargets_pharmgkb/ncbi_utils.py
+++ b/opentargets_pharmgkb/ncbi_utils.py
@@ -1,0 +1,83 @@
+import logging
+
+import requests
+
+from requests import RequestException
+from retry import retry
+
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+eutils_url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/'
+esearch_url = eutils_url + 'esearch.fcgi'
+esummary_url = eutils_url + 'esummary.fcgi'
+efetch_url = eutils_url + 'efetch.fcgi'
+
+
+@retry(exceptions=(ConnectionError, RequestException), tries=4, delay=2, backoff=1.2, jitter=(1, 3))
+def get_rsid_summaries(rsids, api_key=None):
+    payload = {'db': 'snp', 'id': ','.join(rsids), 'retmode': 'JSON'}
+    if api_key:
+        payload['api_key'] = api_key
+    req = requests.get(esummary_url, params=payload)
+    req.raise_for_status()
+    data = req.json()
+    if 'result' in data:
+        results = data['result']
+        results.pop('uids')
+        return results
+    return {}
+
+
+def parse_spdi_from_ncbi_result(ncbi_result):
+    """
+    Parse SPDI expressions from NCBI result.
+
+    :param ncbi_result: dict response from NCBI summary endpoint for a single rsID
+    :return: SPDI coords (chrom, pos, ref, list of alts)
+    """
+    spdis = ncbi_result['spdi'].split(',')
+    # Parse each SPDI into coordinates
+    chrom = pos = ref = None
+    alts = []
+    for spdi in spdis:
+        # TODO warn or something if chrom/pos/ref differs among these
+        chrom, pos, ref, alt = spdi.split(':')
+        alts.append(alt)
+    return chrom, pos, ref, alts
+
+
+def get_spdi_coords_for_rsid(rsid):
+    """
+    Return SPDI coordinates for a single rsIDs by querying NCBI.
+
+    :param rsid:
+    :return: dict mapping rsid to SPDI coords as tuple (chrom, pos, ref, list of alts)
+    """
+    if rsid.startswith('rs'):
+        rsid = rsid[2:]
+    summary_result = get_rsid_summaries([rsid])
+    if rsid not in summary_result:
+        logger.warning(f'Could not get SPDI from NCBI for rs{rsid}')
+        return None, None, None, []
+    return parse_spdi_from_ncbi_result(summary_result[rsid])
+
+
+def get_spdi_coords_for_rsids(rsids):
+    """
+    Return SPDI coordinates for a list of rsIDs, using single batch query to NCBI.
+
+    :param rsids: list of rsIDs
+    :return: dict mapping rsid to SPDI coords as tuple (chrom, pos, ref, list of alts)
+    """
+    rsids = [rs[2:] if rs.startswith('rs') else rs for rs in rsids]
+    summary_results = get_rsid_summaries(rsids)
+    rsid_to_spdis = {}
+    for k in summary_results:
+        rsid = f'rs{k}'
+        rsid_to_spdis[rsid] = parse_spdi_from_ncbi_result(summary_results[k])
+    if set(rsids) != set(rsid_to_spdis.keys()):
+        logger.warning('Did not get SPDI from NCBI for all rsids')
+    return rsid_to_spdis

--- a/opentargets_pharmgkb/ncbi_utils.py
+++ b/opentargets_pharmgkb/ncbi_utils.py
@@ -39,14 +39,20 @@ def parse_spdi_from_ncbi_result(spdi_result):
     :return: SPDI coords (chrom, pos, ref, list of alts)
     """
     spdis = spdi_result.split(',')
-    # Parse each SPDI into coordinates
-    chrom = pos = ref = None
+    chrom_set = set()
+    pos_set = set()
+    ref_set = set()
     alts = []
+    # Parse each SPDI into coordinates
     for spdi in spdis:
-        # TODO warn or something if chrom/pos/ref differs among these
         chrom, pos, ref, alt = spdi.split(':')
+        chrom_set.add(chrom)
+        pos_set.add(pos)
+        ref_set.add(ref)
         alts.append(alt)
-    return chrom, int(pos), ref, alts
+    if len(chrom_set) > 1 or len(pos_set) > 1 or len(ref_set) > 1:
+        logger.warning(f'Unexpected multiples found in SPDIs: {",".join(s for s in spdis)}')
+    return chrom_set.pop(), int(pos_set.pop()), ref_set.pop(), alts
 
 
 def get_spdi_coords_for_rsid(rsid):

--- a/opentargets_pharmgkb/variant_coordinates.py
+++ b/opentargets_pharmgkb/variant_coordinates.py
@@ -104,6 +104,8 @@ class Fasta:
         :return: normalised coordinates (chrom, pos, ref)
         """
         chrom, pos, ref, alts = get_spdi_coords_for_rsid(rsid)
+        # Add 1 to position to be compatible with VCF coordinates
+        pos += 1
         chrom, norm_pos, norm_ref, norm_alts = self.normalise_with_ref(chrom, pos, ref, alts)
         # Don't actually need the alts from SPDI
         return chrom, norm_pos, norm_ref

--- a/tests/test_evidence_generation.py
+++ b/tests/test_evidence_generation.py
@@ -94,8 +94,7 @@ def test_pipeline():
         data_dir=resources_dir,
         fasta_path=fasta_path,
         created_date='2023-03-23',
-        output_path=output_path,
-        debug_path=f'{output_path}.csv'
+        output_path=output_path
     )
 
     with open(output_path) as test_output, open(expected_path) as expected_output:
@@ -103,8 +102,6 @@ def test_pipeline():
 
     if os.path.exists(output_path):
         os.remove(output_path)
-    if os.path.exists(f'{output_path}.csv'):
-        os.remove(f'{output_path}.csv')
 
 
 def test_pipeline_missing_file():

--- a/tests/test_ncbi_utils.py
+++ b/tests/test_ncbi_utils.py
@@ -1,0 +1,6 @@
+from opentargets_pharmgkb.ncbi_utils import get_spdi_coords_for_rsid
+
+
+def test_get_spdi_coords_for_rsid():
+    assert get_spdi_coords_for_rsid('rs35068180') == ('NC_000011.10', 102845216, 'AAAAA', ['AAAA', 'AAAAAA', 'AAAAAAA'])
+    assert get_spdi_coords_for_rsid('rs3000000000') == (None, None, None, [])

--- a/tests/test_variant_coordinates.py
+++ b/tests/test_variant_coordinates.py
@@ -62,3 +62,6 @@ def test_normalise(fasta: Fasta):
     assert fasta.normalise('NC_000021.9', 7678489, ['ATTTATTT', 'ATTT']) == ('NC_000021.9', 7678481, ['TTTTA', 'T'])
     # Same variant with different representation (empty allele)
     assert fasta.normalise('NC_000021.9', 7678489, ['ATTT', '']) == ('NC_000021.9', 7678481, ['TTTTA', 'T'])
+    # Multiple alternate alleles
+    assert fasta.normalise('NC_000021.9', 7678489, ['ATTTATTT', 'ATTT', 'ATTTATTTATTT']) \
+           == ('NC_000021.9', 7678481, ['TTTTA', 'T', 'TTTTATTTA'])

--- a/tests/test_variant_coordinates.py
+++ b/tests/test_variant_coordinates.py
@@ -38,14 +38,14 @@ def test_get_coordinates_not_match_reference_snp(fasta: Fasta):
         'rs1051266',
         'NC_000021.9:45537880',
         [['C', 'C'], ['C', 'G'], ['G', 'G']]
-    ) == ('21', 45537879, 'T', {'C': 'C', 'G': 'G'})
+    ) == ('21', 45537880, 'T', {'C': 'C', 'G': 'G'})
 
 
 def test_get_coordinates_not_match_reference_del(fasta: Fasta):
     # Deletion
     # Mock NCBI response, so we can simulate an exact scenario on chr21 without searching for the right RS
     with patch('opentargets_pharmgkb.variant_coordinates.get_spdi_coords_for_rsid') as m_spdi_coords:
-        m_spdi_coords.return_value = ('NC_000021.9', 45537880, 'TGCTGC', ['TGC'])
+        m_spdi_coords.return_value = ('NC_000021.9', 45537879, 'TGCTGC', ['TGC'])
         result = fasta.get_chr_pos_ref(
             'rs1051266',
             'NC_000021.9:45537880_45537885',

--- a/tests/test_variant_coordinates.py
+++ b/tests/test_variant_coordinates.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from opentargets_pharmgkb.variant_coordinates import Fasta, parse_genotype
 
 
@@ -30,9 +32,33 @@ def test_get_coordinates_range_location(fasta: Fasta):
     ) == ('21', 33341700, 'AGAC', {'DEL': 'A', 'GAC': 'AGAC'})
 
 
-def test_get_coordinates_from_ncbi(fasta: Fasta):
+def test_get_coordinates_not_match_reference_snp(fasta: Fasta):
+    # Multi-allelic SNP, reference not annotated
     assert fasta.get_chr_pos_ref(
         'rs1051266',
-        'NC_000021.9:45537879',
-        [['TGA', 'TGA'], ['TGA', 'TGAGA'], ['TGAGA', 'TGAGA']]
-    ) == ('21', 45537879, 'T', {'TGA': 'TGA', 'TGAGA': 'TGAGA'})
+        'NC_000021.9:45537880',
+        [['C', 'C'], ['C', 'G'], ['G', 'G']]
+    ) == ('21', 45537879, 'T', {'C': 'C', 'G': 'G'})
+
+
+def test_get_coordinates_not_match_reference_del(fasta: Fasta):
+    # Deletion
+    # Mock NCBI response, so we can simulate an exact scenario on chr21 without searching for the right RS
+    with patch('opentargets_pharmgkb.variant_coordinates.get_spdi_coords_for_rsid') as m_spdi_coords:
+        m_spdi_coords.return_value = ('NC_000021.9', 45537880, 'TGCTGC', ['TGC'])
+        result = fasta.get_chr_pos_ref(
+            'rs1051266',
+            'NC_000021.9:45537880_45537885',
+            [['TGC', 'TGC'], ['TGC', 'DEL'], ['DEL', 'DEL']]
+        )
+        assert result == ('21', 45537879, 'GTGC', {'TGC': 'GTGC', 'DEL': 'G'})
+
+
+def test_normalise(fasta: Fasta):
+    # Section of chr21 consisting of ATTT repeats
+    assert fasta.get_ref_from_fasta('NC_000021.9', 7678481, 7678480 + (10*4)) \
+           == 'TTTTATTTATTTATTTATTTATTTATTTATTTATTTATTT'
+    # Variant that deletes one repeat from the middle is normalised to be left-aligned
+    assert fasta.normalise('NC_000021.9', 7678489, ['ATTTATTT', 'ATTT']) == ('NC_000021.9', 7678481, ['TTTTA', 'T'])
+    # Same variant with different representation (empty allele)
+    assert fasta.normalise('NC_000021.9', 7678489, ['ATTT', '']) == ('NC_000021.9', 7678481, ['TTTTA', 'T'])

--- a/tests/test_variant_coordinates.py
+++ b/tests/test_variant_coordinates.py
@@ -30,9 +30,9 @@ def test_get_coordinates_range_location(fasta: Fasta):
     ) == ('21', 33341700, 'AGAC', {'DEL': 'A', 'GAC': 'AGAC'})
 
 
-def test_get_coordinates_not_match_reference(fasta: Fasta):
+def test_get_coordinates_from_ncbi(fasta: Fasta):
     assert fasta.get_chr_pos_ref(
         'rs1051266',
-        'NC_000021.9:33341701_33341703',
-        [['TTT', 'TTT'], ['TTT', 'DEL'], ['DEL', 'DEL']]
-    ) == ('21', 33341700, None, None)
+        'NC_000021.9:45537879',
+        [['TGA', 'TGA'], ['TGA', 'TGAGA'], ['TGAGA', 'TGAGA']]
+    ) == ('21', 45537879, 'T', {'TGA': 'TGA', 'TGAGA': 'TGAGA'})


### PR DESCRIPTION
Closes #36
Also includes the notebook for #21

Example evidence strings for `rs72549309` ([dbsnp](https://www.ncbi.nlm.nih.gov/snp/rs72549309), [pgkb](https://www.pharmgkb.org/clinicalAnnotation/1447989678))

Reference only:
```{
  "datasourceId": "pharmgkb",
  "datasourceVersion": "2024-04-05",
  "datatypeId": "clinical_annotation",
  "studyId": "1447989678",
  "evidenceLevel": "1A",
  "literature": [
    "10071185",
    "24648345"
  ],
  "genotype": "ATGA/ATGA",
  "genotypeAnnotationText": "The del allele of rs72549309 is assigned no function by CPIC. Patients with the ATGA/ATGA genotype may have increased DPYD activity as compared to those with the ATGA/del or del/del genotypes. Other genetic and clinical factors may also influence catalytic activity of DPYD.",
  "drugFromSource": "fluorouracil",
  "drugFromSourceId": "CHEBI_46345",
  "pgxCategory": "other",
  "genotypeId": "1_97740410_GATGA_GATGA,GATGA",
  "variantRsId": "rs72549309",
  "variantFunctionalConsequenceId": "SO_0002073",
  "targetFromSourceId": "ENSG00000188641"
}
```

With variant:
```
{
  "datasourceId": "pharmgkb",
  "datasourceVersion": "2024-04-05",
  "datatypeId": "clinical_annotation",
  "studyId": "1447989678",
  "evidenceLevel": "1A",
  "literature": [
    "10071185",
    "24648345"
  ],
  "genotype": "ATGA/del",
  "genotypeAnnotationText": "The del allele of rs72549309 is assigned no function by CPIC. Patients with the ATGA/del genotype may have decreased DPYD activity as compared to those with the ATGA/ATGA genotype. Other genetic and clinical factors may also influence catalytic activity of DPYD.",
  "drugFromSource": "fluorouracil",
  "drugFromSourceId": "CHEBI_46345",
  "pgxCategory": "other",
  "genotypeId": "1_97740410_GATGA_G,GATGA",
  "variantRsId": "rs72549309",
  "variantFunctionalConsequenceId": "SO_0001589",
  "targetFromSourceId": "ENSG00000188641"
}
```